### PR TITLE
unbox the mix30 C stub

### DIFF
--- a/PRNG.ml
+++ b/PRNG.ml
@@ -255,7 +255,8 @@ external mix64: int64 -> int64 = "pringo_mix64" "pringo_mix64_unboxed"
   [@@unboxed] [@@noalloc]
 external mix32: int64 -> int32 = "pringo_mix32" "pringo_mix32_unboxed"
   [@@unboxed] [@@noalloc]
-external mix30: int64 -> int = "pringo_mix30"
+external mix30: (int64[@unboxed]) -> int = "pringo_mix30" "pringo_mix30_unboxed"
+  [@@noalloc]
 external mixGamma: int64 -> int64 = "pringo_mixGamma" "pringo_mixGamma_unboxed"
   [@@unboxed] [@@noalloc]
 

--- a/stubs.c
+++ b/stubs.c
@@ -44,16 +44,16 @@ CAMLprim value pringo_mix32(value vz)
   return caml_copy_int32(pringo_mix32_unboxed(Int64_val(vz)));
 }
 
-static inline intnat pringo_mix30_unboxed(uint64_t z)
+CAMLprim value pringo_mix30_unboxed(uint64_t z)
 {
   z = (z ^ (z >> 33)) * 0xff51afd7ed558ccdULL;
   z = (z ^ (z >> 33)) * 0xc4ceb9fe1a85ec53ULL;
-  return (intnat)(z >> 34);
+  return Val_long((intnat)(z >> 34));
 }
 
 CAMLprim value pringo_mix30(value vz)
 {
-  return Val_long(pringo_mix30_unboxed(Int64_val(vz)));
+  return pringo_mix30_unboxed(Int64_val(vz));
 }
 
 static inline uint64_t mix64variant13(uint64_t z)


### PR DESCRIPTION
This function is used when for generating ints, and therefore well worth unboxing like the other stubs.