### PR TITLE
Add `uniform` function producing a random float in (0.0, 1.0)

### DIFF
--- a/PRNG.ml
+++ b/PRNG.ml
@@ -148,7 +148,7 @@ let nativeint =
 let rec uniform g =
   let b = X.bits64 g in
   let n = Int64.shift_right_logical b 11 in
-  if n = 0L then uniform g else Int64.to_float n *. 0x1.p-53
+  if n <> 0L then Int64.to_float n *. 0x1.p-53 else uniform g
 
 let float g bound = uniform g *. bound
 
@@ -221,7 +221,7 @@ let nativeint =
 let rec uniform g =
   let (b, g) = X.bits64 g in
   let n = Int64.shift_right_logical b 11 in
-  if n = 0L then uniform g else (Int64.to_float n *. 0x1.p-53, g)
+  if n <> 0L then (Int64.to_float n *. 0x1.p-53, g) else uniform g
 
 let float bound g = 
   let (f, g) = uniform g in (f *. bound, g)

--- a/PRNG.mli
+++ b/PRNG.mli
@@ -71,7 +71,7 @@ module type STATE = sig
         between [x] and 0.0 are returned.  Implemented as [uniform g *. x].
         Consequently, the values [0.0] and [x] can be returned
         (as a result of floating-point rounding), but not if [x] is
-        [1.0], in which case [float g x] behaves like [uniform g]. *)
+        [1.0], since [float g 1.0] behaves exactly like [uniform g]. *)
 
   val byte: t -> int
   val bits8: t -> int

--- a/PRNG.mli
+++ b/PRNG.mli
@@ -59,10 +59,19 @@ module type STATE = sig
   val bit: t -> bool
     (** Return a Boolean value in [false,true] with 0.5 probability each. *)
 
+  val uniform: t -> float
+    (** Return a floating-point number evenly distributed between 0.0 and 1.0.
+        0.0 and 1.0 are never returned.
+        The result is of the form [n * 2{^-53}], where [n] is a random integer
+        in [(0, 2{^53})]. *)
+
   val float: t -> float -> float
     (** [float g x] returns a floating-point number evenly distributed
-        between 0.0 and [x].  If [x] is negative, negative numbers 
-        between [x] and 0.0 are returned. *)
+        between 0.0 and [x].  If [x] is negative, negative numbers
+        between [x] and 0.0 are returned.  Implemented as [uniform g *. x].
+        Consequently, the values [0.0] and [x] can be returned
+        (as a result of floating-point rounding), but not if [x] is
+        [1.0], in which case [float g x] behaves like [uniform g]. *)
 
   val byte: t -> int
   val bits8: t -> int
@@ -90,7 +99,7 @@ module type STATE = sig
         Note that [int32 Int32.max_int] produces numbers between 0 and
         [Int32.max_int] excluded.  To produce numbers between 0 and
         [Int32.max_int] included, use
-        [Int32.logand (bits32 g) Int64.max_int]. *)
+        [Int32.logand (bits32 g) Int32.max_int]. *)
 
   val bits64: t -> int64
     (** Return a 64-bit integer evenly distributed between
@@ -179,6 +188,7 @@ module type PURE = sig
   val bool: t -> bool * t
   val bit: t -> bool * t
 
+  val uniform: t -> float * t
   val float: float -> t -> float * t
 
   val byte: t -> int * t


### PR DESCRIPTION
This is a follow-up to the discussion that started here: https://github.com/ocaml/RFCs/pull/28#issuecomment-927145085

This PR adds a `uniform` function that returns a random FP number in (0.0, 1.0), i.e. guaranteed to be neither 0.0 nor 1.0.  It documents precisely the shape of the FP numbers returned.

The `float` function is implemented and documented in terms of `uniform`.

The old `float_32` implementation was removed as not really useful and as producing differently-rounded results than the `float_64` implementation.

Cc: @jhjourdan